### PR TITLE
Fixes repeated slot input types bug

### DIFF
--- a/runtime/lib/BlockSpec.gp
+++ b/runtime/lib/BlockSpec.gp
@@ -204,7 +204,7 @@ method slotInfoForIndex BlockSpec slotIndex {
   if (repeatedSlotCount == 0) { error 'The repeated slot spec must have at least one input slot' }
   repeatedSlotStart = (((count slotInfo) - repeatedSlotCount))
   n = (slotIndex - repeatedSlotStart)
-  i = (max 1 ((((n - repeatedSlotStart) % repeatedSlotCount)) + repeatedSlotStart))
+  i = (max 1 ((((n - repeatedSlotStart) % repeatedSlotCount) + 1) + repeatedSlotStart))
   return (at slotInfo i)
 }
 


### PR DESCRIPTION
When calculating the slot index for repeated indexes, we were off by one because the module operation starts at `0` but our arrays -rightfully!- start at 1.