### PR TITLE
Add working server

### DIFF
--- a/runtime/lib/CloudDataServer.gp
+++ b/runtime/lib/CloudDataServer.gp
@@ -6,7 +6,8 @@ to cloudDataHost {
   if (notNil (global 'cloudDataHost')) { return (global 'cloudDataHost') }
 //  return '208.82.117.98'
 //  return '127.0.0.1'
-  return '104.236.119.50' // digial ocean
+//  return '104.236.119.50' // digial ocean
+    return '23.96.54.212'
 }
 
 to cloudDataPort { return 2002 }


### PR DESCRIPTION
The official cloud variable server seems to have gone down, this is just to add working cloud variables to future mods and to anyone who uses the vanilla GP-Mods. I also think it fits the repo better to use a community made server instead of the official one.