### PR TITLE
Fixes exporting app bug

### DIFF
--- a/runtime/lib/Stage.gp
+++ b/runtime/lib/Stage.gp
@@ -132,7 +132,9 @@ method loadPage Stage projectPage {
 	placeRotationCenter m x y
 	addPart morph m
   }
-  clearLibrary (library (findProjectEditor))
+  if (notNil (findProjectEditor)) {
+  	clearLibrary (library (findProjectEditor))
+}
 }
 
 method unloadPage Stage projectPage {


### PR DESCRIPTION
Exporting an app wouldn't have worked for a bit, fixed now.

ProjectEditor lib isn't included on export and so this line crashed exported apps, this fix just tests if the library exists and then clears it.