### PR TITLE
Ditch 16:10

### DIFF
--- a/runtime/lib/Stage.gp
+++ b/runtime/lib/Stage.gp
@@ -39,10 +39,10 @@ method initialize Stage w h {
 }
 
 method setAspectRatio Stage w h {
-  majorAxis = 800
+  majorAxis = 900
   if (or (isNil w) (isNil h)) {
 	w = 16
-	h = 10
+	h = 9
   }
   if (w > h) {
 	newW = majorAxis


### PR DESCRIPTION
Considering only an estimated 7% of desktop screens around the world use the 16:10 aspect ratio ([source](https://gs.statcounter.com/screen-resolution-stats/desktop/worldwide)), I think we should change to the more popular and more widely used 16:9 as our default.